### PR TITLE
Add readSwitchesX3 method

### DIFF
--- a/src/Asuro.cpp
+++ b/src/Asuro.cpp
@@ -284,6 +284,26 @@ int Asuro::readSwitches(void)
     return ((10240000L/tmp-10000L)*_switchFactor+5000L)/10000;
 }
 
+/*
+     Read out switches
+     x^3 Interpolation
+     returns bit field of switch value bit0 = K6, ... , bit5 = K1
+*/
+int Asuro::readSwitchesX3(void)
+{
+    long tmp;
+    pinMode(3, OUTPUT);
+    digitalWrite(3, HIGH);
+    delayMicroseconds(10);
+    tmp = analogRead(switches);	// 0..1023
+    digitalWrite(3, LOW);
+    //-0,1+0,5
+    double x = tmp;
+    int sw = fmax( -2.28599856254619E-07*x*x*x + 0.000682617808856135*x*x - 0.752374263864664*x + 299.852039530042, 0);
+
+    return sw;
+}
+
 
 /*
      Returns the battery voltage

--- a/src/Asuro.h
+++ b/src/Asuro.h
@@ -19,7 +19,6 @@
  
  */
 #include "Arduino.h"
-
 // LED values
 #define OFF     0
 #define ON      1
@@ -62,11 +61,11 @@ public:
      */
     void setSwitchFactor(long switchFactor);
     
-	/*
+    /*
      Get the calculation factor for the switches bit field.
      Standard value is 62 (decimal). 
-	*/
-	long Asuro::getSwitchFactor(void);
+    */
+    long getSwitchFactor(void);
 
     /*
      Initializes the hardware (ports, ADC, PWM)
@@ -110,6 +109,13 @@ public:
      */
     void setFrontLED(unsigned char status);
     
+    /*
+     Read out switches
+     Interpolated x^3
+     returns bit field of switch value bit0 = K6, ... , bit5 = K1
+     */
+    int readSwitchesX3(void);
+
     /*
      Read out switches
      


### PR DESCRIPTION
The voltage representing the pressed switches on the analog digital converter does not behave completely linearly.
If a button seems to bounce, the function `readSwitchesX3()` can be used.